### PR TITLE
Write linked Brightway databases in one high-level workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,39 @@ Jupyter notebook.
 
 Recommended python version: 3.11.8
 
+## User workflow
+
+The recommended user-side workflow is now:
+
+```python
+import regioinvent
+
+regio = regioinvent.Regioinvent(
+    bw_project_name="your-brightway-project",
+    ecoinvent_database_name="your-ecoinvent-database",
+    ecoinvent_version="3.10.1",
+)
+
+regio.spatialize_my_ecoinvent()
+regio.import_fully_regionalized_impact_method()  # optional
+regio.regionalize_ecoinvent_with_trade(
+    trade_database_path="/path/to/trade_data.db",
+    target_database_name="Regioinvent",
+    cutoff=0.99,
+)
+```
+
+Important notes:
+- `spatialize_my_ecoinvent()` now writes `biosphere3_spatialized_flows`, but keeps the spatialized ecoinvent copy in memory at this stage.
+- `regionalize_ecoinvent_with_trade(...)` now performs the in-memory relinking between the spatialized ecoinvent copy and the regioinvent database, and then writes both Brightway databases at the end of the workflow.
+- You no longer need to call `write_database()` separately after `regionalize_ecoinvent_with_trade(...)` in the normal high-level workflow.
+- The final Brightway databases are:
+  - `your-ecoinvent-database - regionalized`
+  - the `target_database_name` you passed, e.g. `Regioinvent`
+
 ## How to use after running the code?
-Once the regionalized version of ecoinvent is created on Python, it can be exported to your Brightway
-project. You will then be able to perform your LCAs either through Brightway or activity-browser as you would with the regular ecoinvent database. <br>
+Once the workflow has finished, the spatialized ecoinvent copy and the regioinvent database have already been written to your Brightway
+project. You can then perform your LCAs either through Brightway or activity-browser as you would with the regular ecoinvent database. <br>
 Do note that calculations can be longer with ```Regioinvent``` depending on the cutoff you select. WIth a cutoff of 0.75,
 calculations times are similar to ones with normal ecoinvent (a few seconds). With a cutoff of 0.99, the size of the
 regioinvent database increases 

--- a/doc/demo.ipynb
+++ b/doc/demo.ipynb
@@ -26,14 +26,22 @@
    "execution_count": 1,
    "id": "01366db1-cbce-449b-839e-dbcc07ad2a28",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m13:52:49+0200\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mCan't import `SimaProBlockCSVImporter` - please install `bw2io` with `pip install bw2io[multifunctional]` or install `multifunctional` and `bw_simapro_csv` manually.\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
     "import sys\n",
     "# change the path here to wherever you stored the Regioinvent Python package \n",
     "# only needed if you've not installed through pip\n",
-    "sys.path.append('C://Users/11max/PycharmProjects/Regioinvent/src/')\n",
+    "#sys.path.append('C://Users/11max/PycharmProjects/Regioinvent/src/')\n",
     "import regioinvent"
    ]
   },
@@ -45,8 +53,16 @@
    "outputs": [],
    "source": [
     "import bw2data\n",
-    "bw2data.projects.set_current(\"ecoinvent3.10\")"
+    "bw2data.projects.set_current(\"ecoinvent-3.10-cutoff\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5862907d-6315-48f1-9a53-c870e780df08",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -57,11 +73,18 @@
     {
      "data": {
       "text/plain": [
-       "Databases dictionary with 4 object(s):\n",
-       "\tbiosphere3\n",
-       "\tbiosphere3_spatialized_flows\n",
-       "\tecoinvent-3.10.1-cutoff\n",
-       "\tecoinvent-3.10.1-cutoff - regionalized"
+       "Databases dictionary with 36 objects, including:\n",
+       "\tAluminium\n",
+       "\tAntimony\n",
+       "\tArsenic\n",
+       "\tBeryllium\n",
+       "\tBismuth\n",
+       "\tBoron\n",
+       "\tCadmium\n",
+       "\tChromium\n",
+       "\tCobalt\n",
+       "\tCopper\n",
+       "Use `list(this object)` to get the complete list."
       ]
      },
      "execution_count": 3,
@@ -108,7 +131,7 @@
    "outputs": [],
    "source": [
     "regio = regioinvent.Regioinvent(\n",
-    "    bw_project_name='ecoinvent3.10',\n",
+    "    bw_project_name=\"ecoinvent-3.10-cutoff\",\n",
     "    ecoinvent_database_name='ecoinvent-3.10.1-cutoff',\n",
     "    ecoinvent_version='3.10.1'\n",
     ")"
@@ -126,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "f386fd5d-8073-4d0f-a96e-be9151cdbaf0",
    "metadata": {},
    "outputs": [
@@ -134,29 +157,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-04-16 17:02:49,837 - Regioinvent - INFO - Creating spatialized biosphere flows...\n",
-      "Writing activities to SQLite3 database:\n",
-      "0% [##############################] 100% | ETA: 00:00:00\n",
-      "Total time elapsed: 00:00:03\n"
+      "2026-04-23 13:53:16,829 - Regioinvent - INFO - Creating spatialized biosphere flows...\n",
+      "100%|████████████████████████████████| 110559/110559 [00:02<00:00, 42824.03it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Title: Writing activities to SQLite3 database:\n",
-      "  Started: 04/16/2026 17:02:51\n",
-      "  Finished: 04/16/2026 17:02:54\n",
-      "  Total time elapsed: 00:00:03\n",
-      "  CPU %: 101.20\n",
-      "  Memory %: 1.80\n"
+      "\u001b[2m13:53:20+0200\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mVacuuming database            \u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-04-16 17:06:28,724 - Regioinvent - INFO - Extracting ecoinvent to wurst...\n"
+      "\n",
+      "2026-04-23 13:53:35,092 - Regioinvent - INFO - Extracting ecoinvent to wurst...\n"
      ]
     },
     {
@@ -170,7 +187,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████| 23523/23523 [00:00<00:00, 87234.23it/s]\n"
+      "100%|█████████████████████████████████| 23523/23523 [00:00<00:00, 253557.09it/s]\n"
      ]
     },
     {
@@ -184,7 +201,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|███████████████████████████████████████████████████████████████████████| 743409/743409 [00:34<00:00, 21574.39it/s]\n"
+      "100%|████████████████████████████████| 743409/743409 [00:33<00:00, 22036.05it/s]\n"
      ]
     },
     {
@@ -198,8 +215,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████| 23523/23523 [00:02<00:00, 11255.39it/s]\n",
-      "2026-04-16 17:07:08,155 - Regioinvent - INFO - Spatializing ecoinvent...\n"
+      "100%|███████████████████████████████████| 23523/23523 [00:02<00:00, 8089.88it/s]\n",
+      "2026-04-23 13:54:19,034 - Regioinvent - INFO - Spatializing ecoinvent...\n"
      ]
     }
    ],
@@ -212,10 +229,10 @@
    "id": "87383a6f-e062-46fb-afec-76eed2dd86cb",
    "metadata": {},
    "source": [
-    "This creates two databases in your brightway2 project:\n",
+    "At this stage, regioinvent writes only one database to your brightway2 project:\n",
     "- \"_biosphere3_spatialized_flows_\", which contains all the newly created spatialized elementary flows\n",
-    "- \"the-name-of-your-ecoinvent-database regionalized\", which is a copy of the original ecoinvent but using spatialized elementary flows\n",
-    "You thus end up with two ecoinvent versions: the original one and a spatialized one."
+    "\n",
+    "The spatialized copy of ecoinvent is prepared fully in memory at this step. It is written later, together with the regioinvent database, once both databases have been fully relinked."
    ]
   },
   {
@@ -228,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "716d3cc7-e9c1-48f9-9e47-8d9e285cca24",
    "metadata": {
     "scrolled": true
@@ -238,150 +255,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-04-21 13:25:55,647 - Regioinvent - INFO - Importing all available fully regionalized lcia methods for ecoinvent3.10.\n",
-      "2026-04-21 13:25:55,647 - Regioinvent - INFO - IMPACT World+ v2.1 already present in Brightway project; skipping import.\n"
+      "2026-04-23 13:54:32,673 - Regioinvent - INFO - Importing all available fully regionalized lcia methods for ecoinvent3.10.\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True}\n",
-      "{'cls': <class 'bw2io.package.BW2Package'>, 'metadata': {'module': 'bw2data.method', 'name': 'Method'}, 'apply_whitelist': True, 'Method': <class 'bw2data.method.Method'>}\n"
+     "ename": "UnknownObject",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mUnknownObject\u001b[39m                             Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mregio\u001b[49m\u001b[43m.\u001b[49m\u001b[43mimport_fully_regionalized_impact_method\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/GitHub/Regioinvent/src/regioinvent/main.py:251\u001b[39m, in \u001b[36mRegioinvent.import_fully_regionalized_impact_method\u001b[39m\u001b[34m(self, lcia_method)\u001b[39m\n\u001b[32m    250\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mimport_fully_regionalized_impact_method\u001b[39m(\u001b[38;5;28mself\u001b[39m, lcia_method=\u001b[33m\"\u001b[39m\u001b[33mall\u001b[39m\u001b[33m\"\u001b[39m):\n\u001b[32m--> \u001b[39m\u001b[32m251\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mworkflow_import_fully_regionalized_impact_method\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlcia_method\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/GitHub/Regioinvent/src/regioinvent/workflows/lcia_methods.py:60\u001b[39m, in \u001b[36mimport_fully_regionalized_impact_method\u001b[39m\u001b[34m(regio, lcia_method)\u001b[39m\n\u001b[32m     55\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m lcia_method == \u001b[33m\"\u001b[39m\u001b[33mall\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m regio.ecoinvent_version == \u001b[33m\"\u001b[39m\u001b[33m3.10\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m     56\u001b[39m     regio.logger.info(\n\u001b[32m     57\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mImporting all available fully regionalized lcia methods for ecoinvent3.10.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     58\u001b[39m     )\n\u001b[32m---> \u001b[39m\u001b[32m60\u001b[39m     \u001b[43m_import_method_package\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     61\u001b[39m \u001b[43m        \u001b[49m\u001b[43mregio\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     62\u001b[39m \u001b[43m        \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mdata/IW/impact_world_plus_21_regionalized-for-ecoinvent-v310.0fffd5e3daa5f4cf11ef83e49c375827.bw2package\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     63\u001b[39m \u001b[43m        \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mIMPACT World+ v2.1\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     64\u001b[39m \u001b[43m        \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mIMPACT World+ v2.1\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     65\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     66\u001b[39m     _import_method_package(\n\u001b[32m     67\u001b[39m         regio,\n\u001b[32m     68\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mdata/EF/EF31_regionalized-for-ecoinvent-v310.87ec66ed7e5775d0132d1129fb5caf03.bw2package\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     69\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mEF v3.1\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     70\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mEF v3.1\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     71\u001b[39m     )\n\u001b[32m     72\u001b[39m     _import_method_package(\n\u001b[32m     73\u001b[39m         regio,\n\u001b[32m     74\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mdata/ReCiPe/ReCiPe_regionalized-for-ecoinvent-v310.dd7e66b1994d898394e3acfbed8eef83.bw2package\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     75\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mReCiPe 2016 v1.03 (H)\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     76\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mReCiPe 2016 v1.03 (H)\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     77\u001b[39m     )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/GitHub/Regioinvent/src/regioinvent/workflows/lcia_methods.py:26\u001b[39m, in \u001b[36m_import_method_package\u001b[39m\u001b[34m(regio, relpath, method_fragment, label)\u001b[39m\n\u001b[32m     24\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m as_file(files(\u001b[33m\"\u001b[39m\u001b[33mregioinvent\u001b[39m\u001b[33m\"\u001b[39m).joinpath(relpath)) \u001b[38;5;28;01mas\u001b[39;00m file_path:\n\u001b[32m     25\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m26\u001b[39m         \u001b[43mbi\u001b[49m\u001b[43m.\u001b[49m\u001b[43mBW2Package\u001b[49m\u001b[43m.\u001b[49m\u001b[43mimport_file\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfile_path\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     27\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mEOFError\u001b[39;00m:\n\u001b[32m     28\u001b[39m         regio.logger.warning(\n\u001b[32m     29\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mFailed importing \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mlabel\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m due to EOFError while backing up existing methods. \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     30\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mThis usually means methods already exist with corrupted backup state. \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     31\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mSkipping import.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     32\u001b[39m         )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/homebrew/Caskroom/miniforge/base/envs/regioinvent25/lib/python3.12/site-packages/bw2io/package.py:241\u001b[39m, in \u001b[36mBW2Package.import_file\u001b[39m\u001b[34m(cls, filepath, whitelist)\u001b[39m\n\u001b[32m    239\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mcls\u001b[39m._create_obj(loaded)\n\u001b[32m    240\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m241\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m [\u001b[38;5;28;43mcls\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_create_obj\u001b[49m\u001b[43m(\u001b[49m\u001b[43mo\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m o \u001b[38;5;129;01min\u001b[39;00m loaded]\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/homebrew/Caskroom/miniforge/base/envs/regioinvent25/lib/python3.12/site-packages/bw2io/package.py:132\u001b[39m, in \u001b[36mBW2Package._create_obj\u001b[39m\u001b[34m(cls, data)\u001b[39m\n\u001b[32m    129\u001b[39m     instance.backup()\n\u001b[32m    130\u001b[39m     instance.metadata = data[\u001b[33m\"\u001b[39m\u001b[33mmetadata\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m--> \u001b[39m\u001b[32m132\u001b[39m \u001b[43minstance\u001b[49m\u001b[43m.\u001b[49m\u001b[43mwrite\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdata\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mdata\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    133\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m instance\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/homebrew/Caskroom/miniforge/base/envs/regioinvent25/lib/python3.12/site-packages/bw2data/method.py:115\u001b[39m, in \u001b[36mMethod.write\u001b[39m\u001b[34m(self, data, process)\u001b[39m\n\u001b[32m    112\u001b[39m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    113\u001b[39m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mtuple\u001b[39m(line)\n\u001b[32m--> \u001b[39m\u001b[32m115\u001b[39m data = [\u001b[43mnormalize_ids\u001b[49m\u001b[43m(\u001b[49m\u001b[43mline\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m line \u001b[38;5;129;01min\u001b[39;00m data]\n\u001b[32m    116\u001b[39m third = \u001b[38;5;28;01mlambda\u001b[39;00m x: x[\u001b[32m2\u001b[39m] \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(x) == \u001b[32m3\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    118\u001b[39m geocollections = {\n\u001b[32m    119\u001b[39m     get_geocollection(third(elem), default_global_location=\u001b[38;5;28;01mTrue\u001b[39;00m) \u001b[38;5;28;01mfor\u001b[39;00m elem \u001b[38;5;129;01min\u001b[39;00m data\n\u001b[32m    120\u001b[39m }\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/homebrew/Caskroom/miniforge/base/envs/regioinvent25/lib/python3.12/site-packages/bw2data/method.py:107\u001b[39m, in \u001b[36mMethod.write.<locals>.normalize_ids\u001b[39m\u001b[34m(line)\u001b[39m\n\u001b[32m    105\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m (line[\u001b[32m0\u001b[39m].id, *line[\u001b[32m1\u001b[39m:])\n\u001b[32m    106\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(line[\u001b[32m0\u001b[39m], \u001b[38;5;28mtuple\u001b[39m):\n\u001b[32m--> \u001b[39m\u001b[32m107\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m (\u001b[43mget_node\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m=\u001b[49m\u001b[43mline\u001b[49m\u001b[43m[\u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m.id, *line[\u001b[32m1\u001b[39m:])\n\u001b[32m    108\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(line[\u001b[32m0\u001b[39m], \u001b[38;5;28mint\u001b[39m):\n\u001b[32m    109\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[32m    110\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mCan\u001b[39m\u001b[33m'\u001b[39m\u001b[33mt understand elementary flow identifier \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mline[\u001b[32m0\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m in data line \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mline\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m    111\u001b[39m     )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/homebrew/Caskroom/miniforge/base/envs/regioinvent25/lib/python3.12/site-packages/bw2data/utils.py:384\u001b[39m, in \u001b[36mget_node\u001b[39m\u001b[34m(**kwargs)\u001b[39m\n\u001b[32m    382\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m MultipleResults(\u001b[33m\"\u001b[39m\u001b[33mFound \u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[33m results for the given search\u001b[39m\u001b[33m\"\u001b[39m.format(\u001b[38;5;28mlen\u001b[39m(candidates)))\n\u001b[32m    383\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m candidates:\n\u001b[32m--> \u001b[39m\u001b[32m384\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m UnknownObject\n\u001b[32m    385\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m candidates[\u001b[32m0\u001b[39m]\n",
+      "\u001b[31mUnknownObject\u001b[39m: "
      ]
     }
    ],
@@ -396,13 +289,15 @@
    "source": [
     "If you want to go further in the regionalization, i.e., to create new national production processes and to rely on trade data to create regionalized consumption markets of ecoinvent, you can run the next function. There are 3 arguments:\n",
     "- _trade_database_path_ which is the path where you stored the trade database you downloaded from Zenodo: https://doi.org/10.5281/zenodo.11583814\n",
-    "- _regioinvent_database_name_ which is simply the name that the created database will take\n",
-    "- _cutoff_ which is the cut-off (between 0 and 1) beyond which countries will be aggreated as RoW. For more info on what cutoff does, see section \"Selection of countries for regionalization\" of the Methodology.md file."
+    "- _target_database_name_ which is the name that the created regioinvent database will take\n",
+    "- _cutoff_ which is the cut-off (between 0 and 1) beyond which countries will be aggreated as RoW. For more info on what cutoff does, see section \"Selection of countries for regionalization\" of the Methodology.md file.\n",
+    "\n",
+    "This function now runs the in-memory relinking and the final Brightway write for both dependent databases. You no longer need to call `write_database()` separately afterwards."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "12fe15f4-e3e4-439a-9938-dbffc90ae286",
    "metadata": {},
    "outputs": [
@@ -410,60 +305,70 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-04-16 17:07:27,924 - Regioinvent - INFO - Extracting and formatting trade data...\n",
-      "2026-04-16 17:07:42,684 - Regioinvent - INFO - Regionalizing main inputs of internationally-traded products of ecoinvent...\n",
-      "100%|██████████████████████████████████████████████████████████████████████████████| 1982/1982 [01:00<00:00, 32.65it/s]\n",
-      "2026-04-16 17:08:43,463 - Regioinvent - INFO - Regionalizing main inputs of non-internationally traded processes of ecoinvent...\n",
-      "100%|██████████████████████████████████████████████████████████████████████████████████| 67/67 [00:05<00:00, 11.26it/s]\n",
-      "2026-04-16 17:08:49,422 - Regioinvent - INFO - Creating consumption markets for internationally-traded products...\n",
-      "100%|██████████████████████████████████████████████████████████████████████████████| 1982/1982 [00:56<00:00, 35.33it/s]\n",
-      "2026-04-16 17:09:47,823 - Regioinvent - INFO - Link regioinvent processes to each other...\n",
-      "2026-04-16 17:10:13,397 - Regioinvent - INFO - Aggregate duplicates together...\n",
-      "2026-04-16 17:10:23,613 - Regioinvent - INFO - Regionalizing the elementary flows of the regioinvent database...\n",
-      "2026-04-16 17:10:28,183 - Regioinvent - INFO - Connecting ecoinvent to regioinvent processes...\n"
-     ]
-    }
-   ],
-   "source": [
-    "regio.regionalize_ecoinvent_with_trade(\n",
-    "    trade_database_path='C://Users/11max/PycharmProjects/Regioinvent/trade_data.db',\n",
-    "    cutoff=0.99\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "2800c1cf-7449-447d-8e26-ca363a7e64e2",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 17:10:29,293 - Regioinvent - INFO - Write in-memory database to brightway...\n",
-      "2026-04-16 17:10:29,293 - Regioinvent - INFO - Normalizing in-memory datasets before write...\n",
-      "2026-04-16 17:10:41,863 - Regioinvent - INFO - Starting Brightway write...\n",
-      "Writing activities to SQLite3 database:\n",
-      "0% [##############################] 100% | ETA: 00:00:00\n",
-      "Total time elapsed: 00:04:32\n"
+      "2026-04-23 13:55:45,528 - Regioinvent - INFO - Extracting and formatting trade data...\n",
+      "2026-04-23 13:55:56,166 - Regioinvent - INFO - Regionalizing main inputs of internationally-traded products of ecoinvent...\n",
+      "100%|███████████████████████████████████████| 1982/1982 [00:51<00:00, 38.84it/s]\n",
+      "2026-04-23 13:56:47,245 - Regioinvent - INFO - Regionalizing main inputs of non-internationally traded processes of ecoinvent...\n",
+      "100%|███████████████████████████████████████████| 67/67 [00:16<00:00,  3.96it/s]\n",
+      "2026-04-23 13:57:04,253 - Regioinvent - INFO - Creating consumption markets for internationally-traded products...\n",
+      "100%|███████████████████████████████████████| 1982/1982 [00:55<00:00, 35.61it/s]\n",
+      "2026-04-23 13:58:02,595 - Regioinvent - INFO - Link regioinvent processes to each other...\n",
+      "2026-04-23 13:58:24,923 - Regioinvent - INFO - Aggregate duplicates together...\n",
+      "2026-04-23 13:58:34,647 - Regioinvent - INFO - Regionalizing the elementary flows of the regioinvent database...\n",
+      "2026-04-23 13:58:38,788 - Regioinvent - INFO - Connecting ecoinvent to regioinvent processes...\n",
+      "2026-04-23 13:58:40,722 - Regioinvent - INFO - Write linked in-memory databases to brightway...\n",
+      "2026-04-23 13:58:42,201 - Regioinvent - INFO - Writing Brightway database 'ecoinvent-3.10.1-cutoff - regionalized' without processing...\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Title: Writing activities to SQLite3 database:\n",
-      "  Started: 04/16/2026 17:10:45\n",
-      "  Finished: 04/16/2026 17:15:17\n",
-      "  Total time elapsed: 00:04:32\n",
-      "  CPU %: 99.10\n",
-      "  Memory %: 48.45\n"
+      "\u001b[2m13:58:42+0200\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mNot able to determine geocollections for all datasets. This database is not ready for regionalization.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|████████████████████████████████████| 23523/23523 [01:06<00:00, 355.20it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m13:59:49+0200\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mVacuuming database            \u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-04-23 14:00:06,663 - Regioinvent - INFO - Writing Brightway database 'Regioinvent' without processing...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m14:00:09+0200\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mNot able to determine geocollections for all datasets. This database is not ready for regionalization.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  3%|█▏                                  | 7168/228070 [00:33<14:35, 252.37it/s]"
      ]
     }
    ],
    "source": [
-    "regio.write_database()"
+    "regio.regionalize_ecoinvent_with_trade(\n",
+    "    trade_database_path='/Users/romain/GitHub/Regioinvent/dev/trade_data.db',\n",
+    "    target_database_name='Regioinvent',\n",
+    "    cutoff=0.99\n",
+    ")"
    ]
   },
   {
@@ -471,44 +376,16 @@
    "id": "2ed15eb4-8103-4575-9c02-1a0442efe5ec",
    "metadata": {},
    "source": [
-    "This automatically wrote the regioinvent database in your brightway project. So you can now go on brightway2 or AB to perform your LCAs normally with regioinvent."
+    "This call writes both final databases to your brightway project: the spatialized ecoinvent copy (`the-name-of-your-ecoinvent-database - regionalized`) and the regioinvent database (`Regioinvent` in the example above). You can then go on brightway2 or AB to perform your LCAs normally with regioinvent."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "7811afa1-5b19-485f-adad-801fd2e9a4ba",
+   "execution_count": null,
+   "id": "e6ba6b28-154c-44e9-b299-9176974d1f4c",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Databases dictionary with 15 object(s):\n",
-       "\tbiosphere3\n",
-       "\tbiosphere3_spatialized_flows\n",
-       "\tecoinvent-3.10-biosphere\n",
-       "\tecoinvent-3.10-cutoff\n",
-       "\tecoinvent-3.10.1-cutoff\n",
-       "\tecoinvent-3.10.1-cutoff - regionalized\n",
-       "\tei_cutoff_3.10.1_gcam_SSP2-Base_2050 2026-01-25\n",
-       "\tei_cutoff_3.10.1_image_SSP1-L_2025 2026-01-25\n",
-       "\tei_cutoff_3.10.1_remind_SSP1-NPi_2025 2026-01-25\n",
-       "\tei_cutoff_3.10.1_remind_SSP2-PkBudg650_2050 2026-02-04\n",
-       "\tei_cutoff_3.10.1_tiam-ucl_SSP2-RCP19_2050 2026-01-25\n",
-       "\th2_pem\n",
-       "\ttest1\n",
-       "\ttest2\n",
-       "\ttest3"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "bw2data.databases"
-   ]
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -780,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/scripts/generate_regioinvent_database.py
+++ b/scripts/generate_regioinvent_database.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Generate a regionalized Brightway database with regioinvent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import regioinvent
+
+
+SUPPORTED_ECOINVENT_VERSIONS = ("3.9", "3.9.1", "3.10", "3.10.1")
+SUPPORTED_LCIA_METHODS = ("IW v2.1", "EF v3.1", "ReCiPe 2016 v1.03 (H)", "all")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--bw-project-name", required=True, help="Brightway project name")
+    parser.add_argument(
+        "--ecoinvent-database-name",
+        required=True,
+        help="Existing ecoinvent database name inside the Brightway project",
+    )
+    parser.add_argument(
+        "--ecoinvent-version",
+        required=True,
+        choices=SUPPORTED_ECOINVENT_VERSIONS,
+        help="Supported ecoinvent version string",
+    )
+    parser.add_argument(
+        "--trade-database-path",
+        required=True,
+        help="Path to the external SQLite trade database",
+    )
+    parser.add_argument(
+        "--cutoff",
+        type=float,
+        default=0.99,
+        help="Cutoff used to aggregate remaining shares into RoW",
+    )
+    parser.add_argument(
+        "--target-db-name",
+        default=None,
+        help="Optional output Brightway database name",
+    )
+    parser.add_argument(
+        "--lcia-method",
+        choices=SUPPORTED_LCIA_METHODS,
+        default=None,
+        help="Optional packaged regionalized LCIA method import",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    trade_db_path = Path(args.trade_database_path).expanduser().resolve()
+    if not trade_db_path.exists():
+        raise SystemExit(f"Trade database not found: {trade_db_path}")
+
+    regio = regioinvent.Regioinvent(
+        bw_project_name=args.bw_project_name,
+        ecoinvent_database_name=args.ecoinvent_database_name,
+        ecoinvent_version=args.ecoinvent_version,
+    )
+
+    try:
+        regio.spatialize_my_ecoinvent()
+        if args.lcia_method:
+            regio.import_fully_regionalized_impact_method(args.lcia_method)
+        regio.regionalize_ecoinvent_with_trade(
+            trade_database_path=str(trade_db_path),
+            target_database_name=args.target_db_name or f"{args.ecoinvent_database_name} - regioinvent",
+            cutoff=args.cutoff,
+        )
+    finally:
+        if getattr(regio, "trade_conn", None):
+            regio.trade_conn.close()
+
+    print(
+        "Wrote Brightway databases: "
+        f"{regio.regionalized_ecoinvent_db_name} and {regio.target_db_name}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/regioinvent/workflows/regionalization/io_ops.py
+++ b/src/regioinvent/workflows/regionalization/io_ops.py
@@ -5,6 +5,62 @@ import bw2data as bd
 import pandas as pd
 
 
+_MISSING = object()
+
+
+def _as_bw_database_dict(datasets):
+    """
+    Normalize an in-memory database into the mapping shape expected by Brightway.
+    """
+
+    data = {(ds["database"], ds["code"]): ds for ds in datasets}
+
+    for ds in data.values():
+        for exc in ds.get("exchanges", []):
+            if "input" not in exc and "database" in exc and "code" in exc:
+                exc["input"] = (exc["database"], exc["code"])
+            if exc.get("type") == "production" and "output" not in exc:
+                exc["output"] = (ds["database"], ds["code"])
+
+        ds.pop("categories", None)
+        ds.pop("parameters", None)
+
+    return data
+
+
+def _write_databases_unprocessed_then_process(regio, dbs_to_write):
+    """
+    Write mutually dependent Brightway databases in two phases:
+    raw rows first, processing only after both exist in the project.
+    """
+
+    preferences = bd.preferences
+    had_allow_incomplete = "allow incomplete imports" in preferences
+    original_allow_incomplete = preferences.get("allow incomplete imports", _MISSING)
+
+    preferences["allow incomplete imports"] = True
+    if hasattr(preferences, "flush"):
+        preferences.flush()
+
+    try:
+        for db_name, data in dbs_to_write:
+            regio.logger.info(
+                f"Writing Brightway database {db_name!r} without processing..."
+            )
+            bd.Database(db_name).write(data, process=False)
+
+        for db_name, _ in dbs_to_write:
+            regio.logger.info(f"Processing Brightway database {db_name!r}...")
+            bd.Database(db_name).process()
+    finally:
+        if had_allow_incomplete:
+            preferences["allow incomplete imports"] = original_allow_incomplete
+        else:
+            preferences.pop("allow incomplete imports", None)
+        if hasattr(preferences, "flush"):
+            preferences.flush()
+
+
 def format_trade_data(regio):
     """
     Function extracts and formats the export/import and domestic production data from the trade database
@@ -176,39 +232,40 @@ def write_database_romain(regio, target_db_name=None):
 
 
 def write_database(regio):
+    if not getattr(regio, "_spatialized_in_memory_ready", False) or not regio.ei_wurst:
+        raise ValueError(
+            "No in-memory spatialized ecoinvent found. Run spatialize_my_ecoinvent() first."
+        )
 
-    regio.logger.info("Write regioinvent database to brightway...")
+    regio.logger.info("Write linked in-memory databases to brightway...")
 
-    # change regioinvent data from wurst to bw2 structure
-    regioinvent_data = {
-        (i["database"], i["code"]): i for i in regio.regioinvent_in_wurst
-    }
+    dbs_to_write = [
+        (
+            regio.regionalized_ecoinvent_db_name,
+            _as_bw_database_dict(regio.ei_wurst),
+        )
+    ]
 
-    # recreate inputs in edges (exchanges)
-    for pr in regioinvent_data:
-        for exc in regioinvent_data[pr]["exchanges"]:
-            try:
-                exc["input"]
-            except KeyError:
-                exc["input"] = (exc["database"], exc["code"])
-    # wurst creates empty categories for activities, this creates an issue when you try to write the bw2 database
-    for pr in regioinvent_data:
-        try:
-            del regioinvent_data[pr]["categories"]
-        except KeyError:
-            pass
+    if regio.regioinvent_in_wurst:
+        if not regio.target_db_name:
+            raise ValueError(
+                "No regioinvent target database name set. "
+                "Run regionalize_ecoinvent_with_trade() first."
+            )
+        dbs_to_write.append(
+            (
+                regio.target_db_name,
+                _as_bw_database_dict(regio.regioinvent_in_wurst),
+            )
+        )
 
-    # write regioinvent database in brightway2
-    bd.Database(regio.target_db_name).write(regioinvent_data)
+    _write_databases_unprocessed_then_process(regio, dbs_to_write)
 
 
-def connect_ecoinvent_to_regioinvent_romain(regio):
+def _connect_ecoinvent_to_regioinvent_in_memory(regio):
     """
-    Now that regioinvent exists, we can make ecoinvent use regioinvent processes to further deepen the
-    regionalization. Only countries and sub-countries are connected to regioinvent, simply because in regioinvent
-    we do not have consumption mixes for the different regions of ecoinvent (e.g., RER, RAS, etc.).
-    However, Swiss processes are not affected, as ecoinvent was already tailored for the Swiss case.
-    I am not sure regioinvent would bring more precision in that specific case.
+    Relink the in-memory spatialized ecoinvent copy to the in-memory regioinvent
+    datasets before either database is written to Brightway.
     """
 
     regio.logger.info("Connecting ecoinvent to regioinvent processes...")
@@ -363,221 +420,21 @@ def connect_ecoinvent_to_regioinvent_romain(regio):
                         exc["code"] = regio_dict[match_key]
                         exc["input"] = (exc["database"], exc["code"])
 
-    # Build final in-memory database that can later be written once.
+    # Build final in-memory database that can later be inspected or written.
     regio._final_database_in_memory = list(regio.ei_wurst) + list(regio.regioinvent_in_wurst)
+
+
+def connect_ecoinvent_to_regioinvent_romain(regio):
+    return _connect_ecoinvent_to_regioinvent_in_memory(regio)
 
 
 def connect_ecoinvent_to_regioinvent(regio):
     """
-    Now that regioinvent exists, we can make ecoinvent use regioinvent processes to further deepen the
-    regionalization. Only countries and sub-countries are connected to regioinvent, simply because in regioinvent
-    we do not have consumption mixes for the different regions of ecoinvent (e.g., RER, RAS, etc.).
-    However, Swiss processes are not affected, as ecoinvent was already tailored for the Swiss case.
-    I am not sure regioinvent would bring more precision in that specific case.
+    Relink the in-memory spatialized ecoinvent copy to regioinvent before the
+    two dependent databases are written and processed.
     """
 
-    # Here we are directly manipulating (through bw2) the already-written ecoinvent database
-    regio.logger.info("Connecting ecoinvent to regioinvent processes...")
-
-    # as dictionary to speed searching for information
-    consumption_markets_data = {
-        (i["name"], i["location"]): i
-        for i in regio.regioinvent_in_wurst
-        if "consumption market" in i["name"]
-    }
-    regionalized_products = set(
-        [i["reference product"] for i in regio.regioinvent_in_wurst]
-    )
-    techno_mixes = {
-        (i["name"], i["location"]): i["code"]
-        for i in regio.regioinvent_in_wurst
-        if "technology mix" in i["name"]
-    }
-
-    for process in bd.Database(regio.regionalized_ecoinvent_db_name):
-        # find country/sub-country locations for process, we ignore regions
-        location = None
-        # for countries (e.g., CA)
-        if (
-            process.as_dict()["location"]
-            in regio.country_to_ecoinvent_regions.keys()
-        ):
-            location = process.as_dict()["location"]
-        # for sub-countries (e.g., CA-QC)
-        elif (
-            process.as_dict()["location"].split("-")[0]
-            in regio.country_to_ecoinvent_regions.keys()
-        ):
-            location = process.as_dict()["location"].split("-")[0]
-        # check if location is not None and not Switzerland
-        if location and location != "CH":
-            # loop through technosphere exchanges
-            for exc in process.technosphere():
-                # if the product of the exchange is among the internationally traded commodities
-                if exc.as_dict()["product"] in regio.eco_to_hs_class.keys():
-                    # get the name of the corresponding consumtion market
-                    exc.as_dict()["name"] = (
-                        "consumption market for " + exc.as_dict()["product"]
-                    )
-                    # get the location of the process
-                    exc.as_dict()["location"] = location
-                    # if the consumption market exists for the process location
-                    if (
-                        "consumption market for " + exc.as_dict()["product"],
-                        location,
-                    ) in consumption_markets_data.keys():
-                        exc.as_dict()["database"] = consumption_markets_data[
-                            (
-                                "consumption market for "
-                                + exc.as_dict()["product"],
-                                location,
-                            )
-                        ]["database"]
-                        exc.as_dict()["code"] = consumption_markets_data[
-                            (
-                                "consumption market for "
-                                + exc.as_dict()["product"],
-                                location,
-                            )
-                        ]["code"]
-                    # if the consumption market does not exist for the process location, take RoW
-                    else:
-                        exc.as_dict()["database"] = consumption_markets_data[
-                            (
-                                "consumption market for "
-                                + exc.as_dict()["product"],
-                                "RoW",
-                            )
-                        ]["database"]
-                        exc.as_dict()["code"] = consumption_markets_data[
-                            (
-                                "consumption market for "
-                                + exc.as_dict()["product"],
-                                "RoW",
-                            )
-                        ]["code"]
-                    exc.as_dict()["input"] = (
-                        exc.as_dict()["database"],
-                        exc.as_dict()["code"],
-                    )
-                    exc.save()
-                # if the product of the exchange is among the non-international traded commodities
-                elif (
-                    exc.as_dict()["product"] in regionalized_products
-                    and exc.as_dict()["product"] not in regio.eco_to_hs_class.keys()
-                ):
-                    try:
-                        # if techno mix for location exists
-                        exc.as_dict()["code"] = techno_mixes[
-                            (
-                                "technology mix for " + exc.as_dict()["product"],
-                                location,
-                            )
-                        ]
-                        exc.as_dict()["database"] = regio.target_db_name
-                        exc.as_dict()["name"] = (
-                            "technology mix for " + exc.as_dict()["product"]
-                        )
-                        exc.as_dict()["location"] = location
-                        exc.as_dict()["input"] = (
-                            exc.as_dict()["database"],
-                            exc.as_dict()["code"],
-                        )
-                        exc.save()
-                    except KeyError:
-                        # if not, link to RoW
-                        exc.as_dict()["code"] = techno_mixes[
-                            (
-                                "technology mix for " + exc.as_dict()["product"],
-                                "RoW",
-                            )
-                        ]
-                        exc.as_dict()["database"] = regio.target_db_name
-                        exc.as_dict()["name"] = (
-                            "technology mix for " + exc.as_dict()["product"]
-                        )
-                        exc.as_dict()["location"] = "RoW"
-                        exc.as_dict()["input"] = (
-                            exc.as_dict()["database"],
-                            exc.as_dict()["code"],
-                        )
-                        exc.save()
-
-    # aggregating duplicate inputs (e.g., multiple consumption markets RoW callouts)
-    for process in bd.Database(regio.regionalized_ecoinvent_db_name):
-        duplicates = [
-            item
-            for item, count in collections.Counter(
-                [
-                    (
-                        i.as_dict()["input"],
-                        i.as_dict()["name"],
-                        i.as_dict()["product"],
-                        i.as_dict()["location"],
-                        i.as_dict()["database"],
-                        i.as_dict()["code"],
-                    )
-                    for i in process.technosphere()
-                ]
-            ).items()
-            if count > 1
-        ]
-
-        for duplicate in duplicates:
-            total = sum(
-                [
-                    i["amount"]
-                    for i in process.technosphere()
-                    if i["input"] == duplicate[0]
-                ]
-            )
-            [
-                i.delete()
-                for i in process.technosphere()
-                if i["input"] == duplicate[0]
-            ]
-            new_exc = process.new_exchange(
-                amount=total,
-                type="technosphere",
-                input=duplicate[0],
-                name=duplicate[1],
-                product=duplicate[2],
-                location=duplicate[3],
-                database=duplicate[4],
-                code=duplicate[5],
-            )
-            new_exc.save()
-
-    # we also change production processes of ecoinvent for regionalized production processes of regioinvent
-    regio_dict = {
-        (
-            i.as_dict()["reference product"],
-            i.as_dict()["name"],
-            i.as_dict()["location"],
-        ): i
-        for i in bd.Database(regio.target_db_name)
-    }
-
-    for process in bd.Database(regio.regionalized_ecoinvent_db_name):
-        for exc in process.technosphere():
-            if exc.as_dict()["product"] in regio.eco_to_hs_class.keys():
-                # same thing, we don't touch Swiss processes
-                if exc.as_dict()["location"] not in ["RoW", "CH"]:
-                    try:
-                        exc.as_dict()["database"] = regio.target_db_name
-                        exc.as_dict()["code"] = regio_dict[
-                            (
-                                exc.as_dict()["product"],
-                                exc.as_dict()["name"],
-                                exc.as_dict()["location"],
-                            )
-                        ].as_dict()["code"]
-                        exc.as_dict()["input"] = (
-                            exc.as_dict()["database"],
-                            exc.as_dict()["code"],
-                        )
-                    except KeyError:
-                        pass
+    return _connect_ecoinvent_to_regioinvent_in_memory(regio)
 
 
 def write_regioinvent_to_database(regio):

--- a/src/regioinvent/workflows/regionalization/pipeline.py
+++ b/src/regioinvent/workflows/regionalization/pipeline.py
@@ -38,8 +38,8 @@ def regionalize_ecoinvent_with_trade(regio, trade_database_path, target_database
         regio.create_consumption_markets,
         regio.second_order_regionalization,
         regio.spatialize_elem_flows,
-        regio.write_database,
         regio.connect_ecoinvent_to_regioinvent,
+        regio.write_database,
     ]
     for stage_fn in stages:
         stage_fn()

--- a/src/regioinvent/workflows/spatialization.py
+++ b/src/regioinvent/workflows/spatialization.py
@@ -127,8 +127,3 @@ def spatialize_my_ecoinvent(regio):
             pass
 
     regio._spatialized_in_memory_ready = True
-
-    # write the ecoinvent-regionalized database to brightway
-    bd.Database(regio.regionalized_ecoinvent_db_name).write(
-        regio.ei_regio_data
-    )

--- a/tests/test_entire_workflow.py
+++ b/tests/test_entire_workflow.py
@@ -124,9 +124,9 @@ def configured_regio():
     regio.import_fully_regionalized_impact_method()
     regio.regionalize_ecoinvent_with_trade(
         trade_database_path=trade_db_path,
+        target_database_name=regio_db_name,
         cutoff=cutoff,
     )
-    regio.write_database(target_db_name=regio_db_name)
 
     return regio
 


### PR DESCRIPTION
Keep the spatialized ecoinvent copy and the regioinvent database in memory until they have been fully relinked, then write both with Brightway's two-phase: write with process=False, then process.

User-side workflow is now: 
`spatialize_my_ecoinvent()`
optional `import_fully_regionalized_impact_method()`
then `regionalize_ecoinvent_with_trade(trade_database_path, target_database_name, cutoff)`. 

The high-level workflow now performs the final write itself, so users no longer need a separate `write_database()` call, although this could be re-established if needed.